### PR TITLE
instruct annex to commit text files straight to git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 
 * annex.backend=MD5E
 **/.git* annex.largefiles=nothing
+* annex.largefiles=((mimeencoding=binary)and(largerthan=0))

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,18 @@
-
 * annex.backend=MD5E
 **/.git* annex.largefiles=nothing
 * annex.largefiles=((mimeencoding=binary)and(largerthan=0))
+# machine generated text files better remain in annex
+*.1D annex.largefiles=anything
+*.1D.* annex.largefiles=anything
+*.gii annex.largefiles=anything
+*.gii.* annex.largefiles=anything
+*.grid annex.largefiles=anything
+*.HEAD annex.largefiles=anything
+*.log annex.largefiles=anything
+*.niml annex.largefiles=anything
+*.niml.* annex.largefiles=anything
+*.ply annex.largefiles=anything
+# Since .dotfile, requires use of   -c annex.dotfiles=true  while using git annex directly.
+# Use  datalad save instead  or invoke as git annex add  -c annex.dotfiles=true
+.*.swo annex.largefiles=anything
+*_tstats.txt annex.largefiles=anything


### PR DESCRIPTION
There is no configuration for any files to go to git directly, that seems to make it tricky to manage text files here and they would tend to auto-migrate into git-annex, e.g. as unlocked git annexed files.  With such setting the management of this repo would be made easier but sometimes might still lead to odd "file was annexed and now not" . If you like we can

- [ ] unannex / git-add all non-binary files so they reside explicitly in git.